### PR TITLE
refactor(dropout)!: inference

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -1,0 +1,29 @@
+name: Python tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: DeterminateSystems/flake-checker-action@main
+
+      - name: Install devenv.sh
+        run: nix profile install nixpkgs#devenv
+
+      - name: Run tests
+        run: devenv test

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,10 +3,10 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1733788855,
+        "lastModified": 1739283003,
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "d59fee8696cd48f69cf79f65992269df9891ba86",
+        "rev": "2921e0f7708a69a6f746db58491dd0f0e35cbc8e",
         "type": "github"
       },
       "original": {
@@ -53,30 +53,15 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733749988,
+        "lastModified": 1739138025,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bc27f0fde01ce4e1bfec1ab122d72b7380278e68",
+        "rev": "b2243f41e860ac85c0b446eadc6930359b294e79",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-stable": {
-      "locked": {
-        "lastModified": 1733730953,
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "7109b680d161993918b0a126f38bc39763e5a709",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -87,14 +72,13 @@
         "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "nixpkgs-stable": "nixpkgs-stable"
+        ]
       },
       "locked": {
-        "lastModified": 1733665616,
+        "lastModified": 1737465171,
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "d8c02f0ffef0ef39f6063731fc539d8c71eb463a",
+        "rev": "9364dc02281ce2d37a1f55b6e51f7c0f65a75f17",
         "type": "github"
       },
       "original": {

--- a/devenv.nix
+++ b/devenv.nix
@@ -22,4 +22,6 @@ in
   enterShell = ''
     . .devenv/state/venv/bin/activate
   '';
+
+  enterTest = "uv run pytest tests/";
 }

--- a/equimo/layers/convolution.py
+++ b/equimo/layers/convolution.py
@@ -118,15 +118,15 @@ class ConvBlock(eqx.Module):
     def __call__(
         self,
         x: Float[Array, "channels height width"],
-        enable_dropout: bool,
         key: PRNGKeyArray,
+        inference: Optional[bool] = None,
     ) -> Float[Array, "channels height width"]:
         _, h, w = x.shape
         x2 = self.act(self.norm1(self.conv1(x)))
         x2 = self.norm2(self.conv2(x2))
         x2 = self.depermute(jax.vmap(jax.vmap(self.ls1))(self.permute(x2)))
 
-        return self.drop_path1(x, x2, inference=not enable_dropout, key=key)
+        return self.drop_path1(x, x2, inference=inference, key=key)
 
 
 class SingleConvBlock(eqx.Module):

--- a/equimo/layers/dropout.py
+++ b/equimo/layers/dropout.py
@@ -1,97 +1,10 @@
-import warnings
 from typing import Optional
 
 import equinox as eqx
 import jax
 import jax.lax as lax
-import jax.numpy as jnp
 import jax.random as jrandom
 from jaxtyping import Array, PRNGKeyArray
-
-
-class Dropout(eqx.Module, strict=True):
-    """Applies dropout.
-
-    Note that this layer behaves differently during training and inference. During
-    training then dropout is randomly applied; during inference this layer does nothing.
-    """
-
-    # Let's make them static fields, just to avoid possible filtering issues
-    p: float = eqx.field(static=True)
-    inference: bool = eqx.field(static=True)
-
-    def __init__(
-        self,
-        p: float = 0.5,
-        inference: bool = False,
-        *,
-        deterministic: Optional[bool] = None,
-    ):
-        """**Arguments:**
-
-        - `p`: The fraction of entries to set to zero. (On average.)
-        - `inference`: Whether to actually apply dropout at all. If `True` then dropout
-            is *not* applied. If `False` then dropout is applied. This may be toggled
-            with [`equinox.nn.inference_mode`][] or overridden during
-            [`equinox.nn.Dropout.__call__`][].
-        - `deterministic`: Deprecated alternative to `inference`.
-        """
-
-        if deterministic is not None:
-            inference = deterministic
-            warnings.warn(
-                "Dropout(deterministic=...) is deprecated "
-                "in favour of Dropout(inference=...)"
-            )
-        self.p = p
-        self.inference = inference
-
-    # Backward compatibility
-    @property
-    def deterministic(self):
-        return self.inference
-
-    @jax.named_scope("eqx.nn.Dropout")
-    def __call__(
-        self,
-        x: Array,
-        *,
-        key: Optional[PRNGKeyArray] = None,
-        inference: Optional[bool] = None,
-        deterministic: Optional[bool] = None,
-    ) -> Array:
-        """**Arguments:**
-
-        - `x`: An any-dimensional JAX array to dropout.
-        - `key`: A `jax.random.PRNGKey` used to provide randomness for calculating
-            which elements to dropout. (Keyword only argument.)
-        - `inference`: As per [`equinox.nn.Dropout.__init__`][]. If `True` or
-            `False` then it will take priority over `self.inference`. If `None`
-            then the value from `self.inference` will be used.
-        - `deterministic`: Deprecated alternative to `inference`.
-        """
-
-        if deterministic is not None:
-            inference = deterministic
-            warnings.warn(
-                "Dropout()(deterministic=...) is deprecated "
-                "in favour of Dropout()(inference=...)"
-            )
-
-        if inference is None:
-            inference = self.inference
-        if isinstance(self.p, (int, float)) and self.p == 0:
-            inference = True
-        if inference:
-            return x
-        elif key is None:
-            raise RuntimeError(
-                "Dropout requires a key when running in non-deterministic mode."
-            )
-        else:
-            q = 1 - lax.stop_gradient(self.p)
-            mask = jrandom.bernoulli(key, q, x.shape)
-            return jnp.where(mask, x / q, 0)
 
 
 class DropPath(eqx.Module, strict=True):
@@ -101,9 +14,8 @@ class DropPath(eqx.Module, strict=True):
     training then dropout is randomly applied; during inference this layer does nothing.
     """
 
-    # Let's make them static fields, just to avoid possible filtering issues
-    p: float = eqx.field(static=True)
-    inference: bool = eqx.field(static=True)
+    p: float
+    inference: bool
 
     def __init__(
         self,
@@ -162,9 +74,8 @@ class DropPathAdd(eqx.Module, strict=True):
     training then dropout is randomly applied; during inference this layer does nothing.
     """
 
-    # Let's make them static fields, just to avoid possible filtering issues
-    p: float = eqx.field(static=True)
-    inference: bool = eqx.field(static=True)
+    p: float
+    inference: bool
 
     def __init__(
         self,

--- a/equimo/layers/generic.py
+++ b/equimo/layers/generic.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import equinox as eqx
 from jaxtyping import Array, Float, PRNGKeyArray
 
@@ -38,9 +40,9 @@ class Residual(eqx.Module):
     def __call__(
         self,
         x: Float[Array, "..."],
-        enable_dropout: bool,
         key: PRNGKeyArray,
         pass_args: bool = False,
+        inference: Optional[bool] = None,
     ) -> Float[Array, "..."]:
         """Forward pass of the residual block.
 
@@ -56,13 +58,13 @@ class Residual(eqx.Module):
             with the residual connection through drop path
         """
         if pass_args:
-            x2 = self.module(x, enable_dropout=enable_dropout, key=key)
+            x2 = self.module(x, inference=inference, key=key)
         else:
             x2 = self.module(x)
 
         return self.drop_path(
             x,
             x2,
-            inference=not enable_dropout,
+            inference=inference,
             key=key,
         )

--- a/equimo/layers/mamba.py
+++ b/equimo/layers/mamba.py
@@ -124,8 +124,8 @@ class Mamba2Mixer(eqx.Module):
     def __call__(
         self,
         x: Float[Array, "seqlen dim"],
-        enable_dropout: bool,
         key: PRNGKeyArray,
+        inference: Optional[bool] = None,
     ) -> Float[Array, "seqlen dim"]:
         A = -jnp.exp(self.A_log)
         zxbcdt = jax.vmap(self.in_proj)(x)

--- a/equimo/layers/mamba.py
+++ b/equimo/layers/mamba.py
@@ -1,5 +1,5 @@
 import math
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import equinox as eqx
 import jax

--- a/equimo/layers/sharing.py
+++ b/equimo/layers/sharing.py
@@ -1,5 +1,5 @@
 import math
-from typing import List
+from typing import List, Optional
 
 import equinox as eqx
 import jax

--- a/equimo/layers/sharing.py
+++ b/equimo/layers/sharing.py
@@ -111,15 +111,15 @@ class LayerSharing(eqx.Module):
         self,
         x: Array,
         *args,
-        enable_dropout: bool,
         key: PRNGKeyArray,
+        inference: Optional[bool] = None,
         **kwargs,
     ):
         if self.repeat == 1:
             return self.f(
                 x,
                 *args,
-                enable_dropout=enable_dropout,
+                inference=inference,
                 key=key,
                 **kwargs,
             )
@@ -135,7 +135,7 @@ class LayerSharing(eqx.Module):
                 lora_x = x
             lora_output = self.dropouts[i](
                 jax.vmap(self.loras[i])(lora_x),
-                inference=not enable_dropout,
+                inference=inference,
                 key=keys[i],
             )
             if reshape:
@@ -150,7 +150,7 @@ class LayerSharing(eqx.Module):
                 self.f(
                     x,
                     *args,
-                    enable_dropout=enable_dropout,
+                    inference=inference,
                     key=key,
                     **kwargs,
                 )

--- a/equimo/models/mlla.py
+++ b/equimo/models/mlla.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 import equinox as eqx
 import jax
@@ -136,36 +136,36 @@ class Mlla(eqx.Module):
     def features(
         self,
         x: Float[Array, "..."],
-        enable_dropout: bool,
         key: PRNGKeyArray,
+        inference: Optional[bool] = None,
     ) -> Float[Array, "..."]:
         key_pd, *keys = jr.split(key, 1 + len(self.blocks))
 
         x = self.patch_embed(x)
-        x = self.pos_drop(x, inference=not enable_dropout, key=key_pd)
+        x = self.pos_drop(x, inference=inference, key=key_pd)
         for i, blk in enumerate(self.blocks):
-            x = blk(x, enable_dropout=enable_dropout, key=keys[i])
+            x = blk(x, inference=inference, key=keys[i])
 
         return x
 
     def __call__(
         self,
         x: Float[Array, "..."],
-        enable_dropout: bool,
         key: PRNGKeyArray,
+        inference: Optional[bool] = None,
     ) -> Float[Array, "..."]:
         """Process input through the MLLA model.
 
         Args:
             x: Input tensor (typically an image)
-            enable_dropout: Whether to enable dropout during inference
+            inference: Whether to enable dropout during inference
             key: PRNG key for random operations
 
         Returns:
             Output tensor (class logits if num_classes > 0,
             otherwise feature representations)
         """
-        x = self.features(x, enable_dropout=enable_dropout, key=key)
+        x = self.features(x, inference=inference, key=key)
         x = jax.vmap(self.norm)(x)
         x = reduce(x, "s d -> d", "mean")
         x = self.head(x)

--- a/equimo/models/partialformer.py
+++ b/equimo/models/partialformer.py
@@ -1,4 +1,4 @@
-from typing import Callable, List, Tuple
+from typing import Callable, List, Optional, Tuple
 
 import equinox as eqx
 import jax

--- a/equimo/models/partialformer.py
+++ b/equimo/models/partialformer.py
@@ -9,7 +9,6 @@ from jaxtyping import Array, Float, PRNGKeyArray
 
 from equimo.layers.attention import PartialFormerBlock
 from equimo.layers.convolution import Stem
-from equimo.layers.dropout import Dropout
 from equimo.layers.ffn import Mlp
 from equimo.layers.patch import PatchMerging
 from equimo.layers.posemb import PosCNN
@@ -30,15 +29,15 @@ class LayerSharingWithQA(LayerSharing):
         x: Array,
         qa: Array,
         *args,
-        enable_dropout: bool,
         key: PRNGKeyArray,
+        inference: Optional[bool] = None,
         **kwargs,
     ):
         if self.repeat == 1:
             return self.f(
                 x,
                 *args,
-                enable_dropout=enable_dropout,
+                inference=inference,
                 key=key,
                 **kwargs,
             )
@@ -54,7 +53,7 @@ class LayerSharingWithQA(LayerSharing):
                 lora_x = x
             lora_output = self.dropouts[i](
                 jax.vmap(self.loras[i])(lora_x),
-                inference=not enable_dropout,
+                inference=inference,
                 key=keys[i],
             )
             if reshape:
@@ -68,7 +67,7 @@ class LayerSharingWithQA(LayerSharing):
             x, qa = self.f(
                 x,
                 qa=qa,
-                enable_dropout=enable_dropout,
+                inference=inference,
                 key=key,
                 **kwargs,
             )
@@ -182,8 +181,8 @@ class BlockChunk(eqx.Module):
         x: Float[Array, "seqlen dim"],
         qa: Float[Array, "1 dim"],
         *,
-        enable_dropout: bool,
         key: PRNGKeyArray,
+        inference: Optional[bool] = None,
         **kwargs,
     ) -> Tuple[Float[Array, "..."], Float[Array, "..."]]:
         """Process input features and query attention token.
@@ -191,7 +190,7 @@ class BlockChunk(eqx.Module):
         Args:
             x: Input feature tensor
             qa: Query attention token
-            enable_dropout: Whether to enable dropout
+            inference: Whether to enable dropout
             key: PRNG key for random operations
 
         Returns:
@@ -202,17 +201,15 @@ class BlockChunk(eqx.Module):
         x = self.posemb(x)
 
         for blk, key_block in zip(self.blocks, keys):
-            x, qa = blk(
-                x, qa=qa, enable_dropout=enable_dropout, key=key_block, **kwargs
-            )
+            x, qa = blk(x, qa=qa, inference=inference, key=key_block, **kwargs)
 
         if self.downsampler_contains_dropout:
-            x = self.downsample(x, enable_dropout, key)
+            x = self.downsample(x, inference=inference, key=key)
         else:
             x = self.downsample(x)
         qa = self.qa_drop(
             jax.vmap(self.qa_proj)(qa),
-            inference=not enable_dropout,
+            inference=inference,
             key=key_qadrop,
         )
 
@@ -249,7 +246,7 @@ class PartialFormer(eqx.Module):
 
     qa_token: jnp.ndarray
     patch_embed: Stem
-    pos_drop: Dropout
+    pos_drop: eqx.nn.Dropout
     blocks: List[eqx.Module]
     norm: eqx.Module
     head: eqx.Module
@@ -300,7 +297,7 @@ class PartialFormer(eqx.Module):
             key=key_stem,
         )
 
-        self.pos_drop = Dropout(pos_drop_rate)
+        self.pos_drop = eqx.nn.Dropout(pos_drop_rate)
 
         if drop_path_uniform:
             dpr = [drop_path_rate] * depth
@@ -358,15 +355,15 @@ class PartialFormer(eqx.Module):
     def features(
         self,
         x: Float[Array, "channels height width"],
-        enable_dropout: bool,
         key: PRNGKeyArray,
+        inference: Optional[bool] = None,
         return_qa: bool = False,
     ) -> Float[Array, "seqlen dim"]:
         """Extract features from input image using partial attention.
 
         Args:
             x: Input image tensor
-            enable_dropout: Whether to enable dropout during inference
+            inference: Whether to enable dropout during inference
             key: PRNG key for random operations
 
         Returns:
@@ -374,14 +371,14 @@ class PartialFormer(eqx.Module):
         """
         key_posdrop, *block_subkeys = jr.split(key, len(self.blocks) + 1)
         x = self.patch_embed(x)
-        x = self.pos_drop(x, inference=not enable_dropout, key=key_posdrop)
+        x = self.pos_drop(x, inference=inference, key=key_posdrop)
 
         qa = self.qa_token
         for blk, key_block in zip(self.blocks, block_subkeys):
             x, qa = blk(
                 x,
                 qa=qa,
-                enable_dropout=enable_dropout,
+                inference=inference,
                 key=key_block,
             )
 
@@ -392,20 +389,20 @@ class PartialFormer(eqx.Module):
     def __call__(
         self,
         x: Float[Array, "channels height width"],
-        enable_dropout: bool,
         key: PRNGKeyArray,
+        inference: Optional[bool] = None,
     ) -> Float[Array, "num_classes"]:
         """Process input image through the full network.
 
         Args:
             x: Input image tensor
-            enable_dropout: Whether to enable dropout during inference
+            inference: Whether to enable dropout during inference
             key: PRNG key for random operations
 
         Returns:
             Classification logits for each class
         """
-        x = self.features(x, enable_dropout, key)
+        x = self.features(x, inference=inference, key=key)
         x = jax.vmap(self.norm)(x)
         x = reduce(x, "n c -> c", "mean")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,8 @@ dependencies = [
   "jax>=0.4.25",
   "jaxlib>=0.4.25",
 ]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.3.4",
+]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = "."

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,33 @@
+import equimo.models as em
+import jax.numpy as jnp
+import jax.random as jr
+
+
+def test_vit_inference():
+    key = jr.PRNGKey(42)
+    img_size = 224
+    patch_size = 14
+
+    x1 = jr.normal(key, (3, 224, 224))
+    x2 = jr.normal(key, (3, 98, 98))
+    mask = jr.bernoulli(key, shape=(16, 16)) * 1
+
+    base_model = em.VisionTransformer(
+        img_size=img_size,
+        in_channels=3,
+        dim=384,
+        patch_size=patch_size,
+        num_heads=[6],
+        depths=[12],
+        num_classes=0,
+        use_mask_token=True,
+        dynamic_img_size=True,
+        key=key,
+    )
+
+    # Testing multiple img sizes, inference mode, and masking
+    f1 = base_model.features(x1, mask=mask, inference=True, key=key)
+    f2 = base_model.features(x2, inference=False, key=key)
+
+    assert jnp.all(f1)
+    assert jnp.all(f2)

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+]
+
+[[package]]
 name = "einops"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -17,13 +26,18 @@ wheels = [
 
 [[package]]
 name = "equimo"
-version = "0.1.3a3"
+version = "0.1.3a9"
 source = { virtual = "." }
 dependencies = [
     { name = "einops" },
     { name = "equinox" },
     { name = "jax" },
     { name = "jaxlib" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
 ]
 
 [package.metadata]
@@ -33,6 +47,9 @@ requires-dist = [
     { name = "jax", specifier = ">=0.4.25" },
     { name = "jaxlib", specifier = ">=0.4.25" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.3.4" }]
 
 [[package]]
 name = "equinox"
@@ -46,6 +63,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f0/d1/efc255a296fad39fb704411ca8cc212775fa3fcc0e4a741971216e1098b3/equinox-0.11.9.tar.gz", hash = "sha256:e0f0fa5ea597949492d201ab4d08b05c2d5b4020c65a1778aedf6ad76c2c4fe7", size = 140791 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/6a/aece19b15fe69057e87c5c8accf3209d4c51d57d7997bbdbba49ad543f80/equinox-0.11.9-py3-none-any.whl", hash = "sha256:d9257a5f9d923b18e309ba046bffaf92f49c8b03c577d1df8bc446f9a64055f4", size = 179312 },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
 ]
 
 [[package]]
@@ -176,6 +202,39 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8c/b9/2ac072041e899a52f20cf9510850ff58295003aa75525e58343591b0cbfb/opt_einsum-3.4.0.tar.gz", hash = "sha256:96ca72f1b886d148241348783498194c577fa30a8faac108586b14f1ba4473ac", size = 63004 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl", hash = "sha256:69bb92469f86a1565195ece4ac0323943e83477171b91d24c35afe028a90d7cd", size = 71932 },
+]
+
+[[package]]
+name = "packaging"
+version = "24.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451 },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
+]
+
+[[package]]
+name = "pytest"
+version = "8.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6", size = 343083 },
 ]
 
 [[package]]


### PR DESCRIPTION
This removes the `Dropout` class and renames `enable_dropout` to `inference`.

`enable_dropout` is not mandatory anymore.
This PR also adds a GitHub action to automate tests checks and prevent future breaking changes.

Fixes #2 