### PR TITLE
feat(vit): add support for loading dinov2 giant

### DIFF
--- a/equimo/layers/attention.py
+++ b/equimo/layers/attention.py
@@ -1552,3 +1552,53 @@ class LinearAngularAttention(eqx.Module):
         x = self.proj_drop(x, inference=inference, key=key2)
 
         return x
+
+
+def get_attention(module: str | eqx.Module) -> eqx.Module:
+    """Get an `eqx.Module` from its common name.
+
+    This is necessary because configs have to be stringified and stored as
+    json files to allow (de)serialization.
+    """
+    if not isinstance(module, str):
+        return module
+
+    match module:
+        case "attention":
+            return Attention
+        case "windowedattention":
+            return WindowedAttention
+        case "shsa":
+            return SHSA
+        case "linearattention":
+            return LinearAttention
+        case "mmsa":
+            return MMSA
+        case "sqa":
+            return SQA
+        case "linearangularattention":
+            return LinearAngularAttention
+        case _:
+            raise ValueError(f"Got an unknown module string: {module}")
+
+
+def get_attention_block(module: str | eqx.Module) -> eqx.Module:
+    """Get an `eqx.Module` from its common name.
+
+    This is necessary because configs have to be stringified and stored as
+    json files to allow (de)serialization.
+    """
+    if not isinstance(module, str):
+        return module
+
+    match module:
+        case "attentionblock":
+            return AttentionBlock
+        case "hatblock":
+            return HATBlock
+        case "mllablock":
+            return MllaBlock
+        case "partialformerblock":
+            return PartialFormerBlock
+        case _:
+            raise ValueError(f"Got an unknown module string: {module}")

--- a/equimo/layers/norm.py
+++ b/equimo/layers/norm.py
@@ -85,3 +85,27 @@ class LayerScale(eqx.Module):
             Scaled tensor of same shape as input
         """
         return x * self.gamma
+
+
+def get_norm(module: str | eqx.Module) -> eqx.Module:
+    """Get an `eqx.Module` from its common name.
+
+    This is necessary because configs have to be stringified and stored as
+    json files to allow (de)serialization.
+    """
+    if not isinstance(module, str):
+        return module
+
+    match module:
+        case "layernorm":
+            return eqx.nn.LayerNorm
+        case "rmsnorm":
+            return eqx.nn.RMSNorm
+        case "groupnorm":
+            return eqx.nn.GroupNorm
+        case "rmsnormgated":
+            return RMSNormGated
+        case "layerscale":
+            return LayerScale
+        case _:
+            raise ValueError(f"Got an unknown module string: {module}")

--- a/equimo/utils.py
+++ b/equimo/utils.py
@@ -1,4 +1,5 @@
 from functools import partial
+
 import jax
 import jax.numpy as jnp
 from jaxtyping import Array, Float


### PR DESCRIPTION
This introduces the possibility to load `eqx.Module`s from a string common name.

This new feature enables saving model configs containing classes.
This is currently enabled only for ViTs as I am not sure about its final(stable) api design, and it might change.